### PR TITLE
update build.sbt so that graphframes dependency can be downloaded.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ scalaVersion := "2.11.12"
 
 val sparkVersion = "2.4.0"
 
+
+
 libraryDependencies += "org.apache.spark" %% "spark-core" % s"${sparkVersion}"
 libraryDependencies += "org.apache.spark" %% "spark-streaming" % s"${sparkVersion}"
 libraryDependencies += "org.apache.spark" %% "spark-sql" % s"${sparkVersion}"
@@ -27,5 +29,6 @@ libraryDependencies += "com.h2database" % "h2" % "1.4.195"
 libraryDependencies += "mysql" % "mysql-connector-java" % "6.0.6"
 libraryDependencies += "org.postgresql" % "postgresql" % "42.2.0"
 
-//resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
-libraryDependencies += "graphframes" % "graphframes" % "0.6.0-spark2.3-s_2.11"
+resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
+
+libraryDependencies += "graphframes" % "graphframes" % "0.7.0-spark2.3-s_2.11"


### PR DESCRIPTION
added resolver which was commented out, but for me it would not build unless i added it back in (could not find dependency).

also updated the graph frames version to latest.

Thanks for the great articles BTW.. I'm working through them as I prepare for my spark certification test.